### PR TITLE
Update with current versions of Docker format

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,9 @@
-rest_php_examples:
-  image: php:7.0-apache
-  volumes:
-    - ./www/:/var/www/html/
-  ports:
-    - 6980:80
+version: '3.8'
+
+services:
+  rest_php_examples:
+    image: php:7.0-apache
+    volumes:
+      - ./www/:/var/www/html/
+    ports:
+      - 6980:80


### PR DESCRIPTION
Fix "(root) Additional property rest_php_examples is not allowed" error when start the container with current versions of Docker